### PR TITLE
Remove unnecessary DMA constraint

### DIFF
--- a/nvme_pcie/BUILD.bazel
+++ b/nvme_pcie/BUILD.bazel
@@ -23,7 +23,7 @@ _BINARY_COMPAT = "yes"
 
 _VENDOR = "VMware"
 
-_DRIVER_VER = "1.4.0.3"
+_DRIVER_VER = "1.4.0.4"
 
 _VERSION_BUMP = "1"
 

--- a/nvme_pcie/README
+++ b/nvme_pcie/README
@@ -10,6 +10,10 @@ This is VMware native NVMe PCIe driver compatible with NVMe Specification 1.4.
 
 == Change Log ==
 
+2025/8/21 1.4.0.4-1vmw
+
+   Relax the DMA constraint for buffer sizes.
+
 2025/5/28 1.4.0.3-1vmw
 
    Fix the gcc format-nonliteral error of performance statistics format string.

--- a/nvme_pcie/nvme_pcie.sc
+++ b/nvme_pcie/nvme_pcie.sc
@@ -34,7 +34,7 @@ nvme_pcie_identification = {
    "binary compat"   : "yes",
    "summary"         : "Non-Volatile memory controller driver",
    "description"     : "Non-Volatile memory controller driver",
-   "version"         : "1.4.0.3",
+   "version"         : "1.4.0.4",
    "version_bump"    : 1,
    "license"         : VMK_MODULE_LICENSE_BSD,
    "vendor"          : "VMware",

--- a/nvme_pcie/nvme_pcie_adapter.c
+++ b/nvme_pcie/nvme_pcie_adapter.c
@@ -583,7 +583,7 @@ NVMEPCIEAdapterInit(NVMEPCIEController *ctrlr)
     */
    constraints.sgMaxEntries = NVME_PCIE_SG_MAX_ENTRIES;
    constraints.sgElemMaxSize = 0;
-   constraints.sgElemSizeMult = 512;
+   constraints.sgElemSizeMult = 0;
    constraints.sgElemAlignment = 4;
    constraints.sgElemStraddle = VMK_ADDRESS_MASK_32BIT + 1;
 


### PR DESCRIPTION
This change removes the DMA constraint that requires buffer sizes to be a multiple of 512. This has a side effect of causing bounce buffers to be used when a buffer address is not a multiple of 512.  Runtime testing shows that vSAN IOs are often only 8-byte aligned, and the end result is a significant reduction of performance compared to when this constraint isn't specified.